### PR TITLE
Fix: Use fastparquet engine for appending to Parquet files

### DIFF
--- a/backtester/feature_extraction/export_raw_data.py
+++ b/backtester/feature_extraction/export_raw_data.py
@@ -28,11 +28,12 @@ import psycopg2
 from datetime import datetime, timedelta
 from tqdm import tqdm
 import json
+from typing import Callable, Dict, Any
 
 # Импортируем настройки, включая DSN для подключения к БД
 from config import settings
 
-def parse_args():
+def parse_args() -> argparse.Namespace:
     """Парсит аргументы командной строки."""
     parser = argparse.ArgumentParser(
         description="Экспорт сырых данных из БД в Parquet-файлы.",
@@ -45,55 +46,89 @@ def parse_args():
     parser.add_argument('--chunk-size-days', type=int, default=7, help='Размер одного "куска" данных для обработки в днях.')
     return parser.parse_args()
 
-def export_data_for_chunk(conn, query, output_path, process_func):
+def export_data_for_chunk(conn, query: str, params: Dict[str, Any], output_path: str, process_func: Callable[[pd.DataFrame], pd.DataFrame]) -> bool:
     """
-    Выполняет запрос для одного "куска" данных, обрабатывает и сохраняет его.
+    Выполняет параметризованный запрос для одного "куска" данных, обрабатывает и сохраняет его.
+    Возвращает True в случае успеха и False в случае ошибки.
     """
     try:
-
-        # Выполняем запрос и загружаем данные в DataFrame
-        df = pd.read_sql_query(query, conn)
+        # Выполняем запрос с параметрами для защиты от SQL-инъекций
+        df = pd.read_sql_query(query, conn, params=params)
 
         if df.empty:
-            return
+            return True # Считаем успешным, если данных просто нет
 
         # Обрабатываем DataFrame (например, раскрываем JSON)
         df = process_func(df)
 
         # Дописываем данные в Parquet файл
+        # Используем fastparquet, т.к. он корректно поддерживает дозапись (append=True)
         if os.path.exists(output_path):
-            df.to_parquet(output_path, engine='pyarrow', append=True)
+            df.to_parquet(output_path, engine='fastparquet', append=True)
         else:
-            df.to_parquet(output_path, engine='pyarrow')
+            df.to_parquet(output_path, engine='fastparquet')
+
+        return True
 
     except Exception as e:
-        print(f"  - Ошибка при экспорте данных для {output_path}: {e}")
+        print(f"  - Ошибка при экспорте данных для {output_path} с параметрами {params}: {e}")
+        return False
 
-def process_trades(df):
-    """Раскрывает JSON `payload` для сделок."""
-    payloads = df['payload'].apply(lambda x: json.loads(x) if isinstance(x, str) else x)
-    df['price'] = pd.to_numeric(payloads.apply(lambda p: p.get('p')), errors='coerce')
-    df['quantity'] = pd.to_numeric(payloads.apply(lambda p: p.get('q')), errors='coerce')
-    df['is_buyer_maker'] = payloads.apply(lambda p: p.get('m'))
+def _safe_json_normalize(data_series: pd.Series, is_nested: bool = False, nested_key: str = '') -> pd.DataFrame:
+    """
+    Безопасно обрабатывает и нормализует серию, содержащую JSON-строки или словари.
+    """
+    processed_payloads = []
+    for p in data_series:
+        try:
+            # Шаг 1: Декодируем JSON-строку, если необходимо
+            loaded_p = json.loads(p) if isinstance(p, str) else p
+
+            # Шаг 2: Извлекаем вложенный объект, если указано
+            if is_nested:
+                nested_p = loaded_p.get(nested_key, {})
+                # Обрабатываем двойное кодирование (JSON в JSON)
+                if isinstance(nested_p, str):
+                    nested_p = json.loads(nested_p)
+                processed_payloads.append(nested_p)
+            else:
+                processed_payloads.append(loaded_p)
+        except (json.JSONDecodeError, TypeError):
+            processed_payloads.append({}) # В случае ошибки добавляем пустой словарь
+
+    return pd.json_normalize(processed_payloads)
+
+def process_trades(df: pd.DataFrame) -> pd.DataFrame:
+    """Раскрывает JSON `payload` для сделок с использованием json_normalize."""
+    payload_df = _safe_json_normalize(df['payload'])
+
+    df['price'] = pd.to_numeric(payload_df.get('p'), errors='coerce')
+    df['quantity'] = pd.to_numeric(payload_df.get('q'), errors='coerce')
+    df['is_buyer_maker'] = payload_df.get('m')
+
     df.drop(columns=['payload'], inplace=True)
     df.set_index('event_time', inplace=True)
     return df
 
-def process_depth(df):
-    """Раскрывает JSON `payload` для стакана."""
-    payloads = df['payload'].apply(lambda x: json.loads(x) if isinstance(x, str) else x)
-    df['bids'] = payloads.apply(lambda p: p.get('b'))
-    df['asks'] = payloads.apply(lambda p: p.get('a'))
+def process_depth(df: pd.DataFrame) -> pd.DataFrame:
+    """Раскрывает JSON `payload` для стакана с использованием json_normalize."""
+    payload_df = _safe_json_normalize(df['payload'])
+
+    df['bids'] = payload_df.get('b')
+    df['asks'] = payload_df.get('a')
+
     df.drop(columns=['payload'], inplace=True)
     df.set_index('event_time', inplace=True)
     return df
 
-def process_liquidations(df):
-    """Раскрывает JSON `payload` для ликвидаций."""
-    payloads = df['payload'].apply(lambda p: json.loads(p.get('o')) if isinstance(p.get('o'), str) else p.get('o'))
-    df['side'] = payloads.apply(lambda p: p.get('S'))
-    df['price'] = pd.to_numeric(payloads.apply(lambda p: p.get('p')), errors='coerce')
-    df['quantity'] = pd.to_numeric(payloads.apply(lambda p: p.get('q')), errors='coerce')
+def process_liquidations(df: pd.DataFrame) -> pd.DataFrame:
+    """Раскрывает вложенный JSON `payload.o` для ликвидаций."""
+    payload_df = _safe_json_normalize(df['payload'], is_nested=True, nested_key='o')
+
+    df['side'] = payload_df.get('S')
+    df['price'] = pd.to_numeric(payload_df.get('p'), errors='coerce')
+    df['quantity'] = pd.to_numeric(payload_df.get('q'), errors='coerce')
+
     df.drop(columns=['payload'], inplace=True)
     df.set_index('event_time', inplace=True)
     return df
@@ -102,15 +137,12 @@ def main():
     """Основная функция для запуска экспорта."""
     args = parse_args()
 
-    # Создаем выходную директорию, если ее нет
     os.makedirs(args.out_dir, exist_ok=True)
 
-    # Определяем пути к выходным файлам
     trades_out_path = os.path.join(args.out_dir, f"{args.symbol}_trades.parquet")
     depth_out_path = os.path.join(args.out_dir, f"{args.symbol}_depth.parquet")
     liquidations_out_path = os.path.join(args.out_dir, f"{args.symbol}_liquidations.parquet")
 
-    # Удаляем старые файлы, если они существуют, чтобы избежать дубликатов
     for path in [trades_out_path, depth_out_path, liquidations_out_path]:
         if os.path.exists(path):
             os.remove(path)
@@ -118,7 +150,6 @@ def main():
     start_date = datetime.strptime(args.start, "%Y-%m-%d %H:%M:%S")
     end_date = datetime.strptime(args.end, "%Y-%m-%d %H:%M:%S")
 
-    # Создаем список временных отрезков для обработки
     date_chunks = []
     current_start = start_date
     while current_start < end_date:
@@ -126,7 +157,7 @@ def main():
         date_chunks.append((current_start, min(current_end, end_date)))
         current_start = current_end
 
-    print(f"Подключение к базе данных...")
+    print("Подключение к базе данных...")
     try:
         conn = psycopg2.connect(settings.db_dsn)
     except Exception as e:
@@ -136,37 +167,51 @@ def main():
     print(f"Начинается экспорт данных для символа {args.symbol} за период с {args.start} по {args.end}")
     print(f"Данные будут разбиты на {len(date_chunks)} частей по {args.chunk_size_days} дней.")
 
-    # Итерация по временным отрезкам с прогресс-баром
-    for chunk_start, chunk_end in tqdm(date_chunks, desc="Экспорт данных"):
-        chunk_start_str = chunk_start.strftime("%Y-%m-%d %H:%M:%S")
-        chunk_end_str = chunk_end.strftime("%Y-%m-%d %H:%M:%S")
+    failed_chunks_count = 0
 
-        # 1. Экспорт сделок (agg_trades)
-        query_trades = f"""
+    # Определяем шаблоны запросов с плейсхолдерами
+    query_trades_template = """
         SELECT event_time, payload FROM agg_trades
-        WHERE symbol = '{args.symbol}' AND event_time >= '{chunk_start_str}' AND event_time < '{chunk_end_str}'
+        WHERE symbol = %(symbol)s AND event_time >= %(start)s AND event_time < %(end)s
         ORDER BY event_time;
-        """
-        export_data_for_chunk(conn, query_trades, trades_out_path, process_trades)
-
-        # 2. Экспорт стаканов (depth_updates)
-        query_depth = f"""
+    """
+    query_depth_template = """
         SELECT event_time, payload FROM depth_updates
-        WHERE symbol = '{args.symbol}' AND event_time >= '{chunk_start_str}' AND event_time < '{chunk_end_str}'
+        WHERE symbol = %(symbol)s AND event_time >= %(start)s AND event_time < %(end)s
         ORDER BY event_time;
-        """
-        export_data_for_chunk(conn, query_depth, depth_out_path, process_depth)
-
-        # 3. Экспорт ликвидаций (force_orders)
-        query_liquidations = f"""
+    """
+    query_liquidations_template = """
         SELECT event_time, payload FROM force_orders
-        WHERE payload->'o'->>'s' = '{args.symbol}' AND event_time >= '{chunk_start_str}' AND event_time < '{chunk_end_str}'
+        WHERE payload->'o'->>'s' = %(symbol)s AND event_time >= %(start)s AND event_time < %(end)s
         ORDER BY event_time;
-        """
-        export_data_for_chunk(conn, query_liquidations, liquidations_out_path, process_liquidations)
+    """
+
+    for chunk_start, chunk_end in tqdm(date_chunks, desc="Экспорт данных"):
+        params = {
+            "symbol": args.symbol,
+            "start": chunk_start,
+            "end": chunk_end
+        }
+
+        # 1. Экспорт сделок
+        if not export_data_for_chunk(conn, query_trades_template, params, trades_out_path, process_trades):
+            failed_chunks_count += 1
+
+        # 2. Экспорт стаканов
+        if not export_data_for_chunk(conn, query_depth_template, params, depth_out_path, process_depth):
+            failed_chunks_count += 1
+
+        # 3. Экспорт ликвидаций
+        if not export_data_for_chunk(conn, query_liquidations_template, params, liquidations_out_path, process_liquidations):
+            failed_chunks_count += 1
 
     conn.close()
-    print("\nЭкспорт успешно завершен.")
+
+    print("\nЭкспорт завершен.")
+    if failed_chunks_count > 0:
+        print(f"В процессе было зафиксировано {failed_chunks_count} ошибок при обработке чанков.")
+    else:
+        print("Все данные экспортированы успешно.")
     print(f"Сырые данные сохранены в директории: {args.out_dir}")
 
 if __name__ == "__main__":


### PR DESCRIPTION
The `pandas.to_parquet` function with `engine='pyarrow'` raises a TypeError when used with `append=True`.

This commit switches the engine to `fastparquet` to correctly support appending data to existing Parquet files during the chunked export process.