### PR TITLE
Fix SyntaxError in prepare_dataset.py

### DIFF
--- a/backtester/feature_extraction/prepare_dataset.py
+++ b/backtester/feature_extraction/prepare_dataset.py
@@ -72,12 +72,10 @@ def main():
         print(f"Loading liquidations from {args.liquidations_file}...")
         liquidations_df = pd.read_parquet(args.liquidations_file)
     except FileNotFoundError as e:
-        print(f"
-ERROR: Input file not found: {e}")
+        print(f"ERROR: Input file not found: {e}")
         return
     except Exception as e:
-        print(f"
-ERROR: Failed to load data from Parquet files: {e}")
+        print(f"ERROR: Failed to load data from Parquet files: {e}")
         return
 
     if trades_df.empty:


### PR DESCRIPTION
The script `backtester/feature_extraction/prepare_dataset.py` would fail with a `SyntaxError: unterminated f-string literal` when trying to print error messages within the `try...except` block for loading data.

This was caused by using multi-line f-strings with single quotes (`f"..."`). The fix replaces these with standard, single-line f-strings, which resolves the syntax error and allows the script to run correctly.