### PR TITLE
fix(scripts): Добавить недостающие аргументы в prepare_dataset.sh

### DIFF
--- a/prepare_dataset.sh
+++ b/prepare_dataset.sh
@@ -44,7 +44,11 @@ python -m backtester.feature_extraction.prepare_dataset \
     --delta-window 30 \
     --panic-window 30 \
     --absorption-window 50 \
-    --wall-neighborhood 4
+    --obi-levels 5 \
+    --wall-factor 10.0 \
+    --wall-neighborhood 4 \
+    --imbalance-ratio 3.0 \
+    --imbalance-window 100
 
 echo "--- ЭТАП 2 Завершен ---"
 echo "Финальный датасет с признаками сохранен в: $FEATURES_FILE"


### PR DESCRIPTION
Скрипт `prepare_dataset.sh` не передавал аргументы командной строки для конфигурации новых индикаторов (`Order Book Imbalance`, `Liquidity Wall Analysis`, `Footprint Imbalance`), хотя соответствующий Python-скрипт `prepare_dataset.py` их поддерживал.

Это изменение добавляет недостающие аргументы в вызов скрипта, используя значения по умолчанию, определенные в `prepare_dataset.py`. Это позволяет полностью активировать и настраивать все реализованные функции при запуске конвейера подготовки данных.