### PR TITLE
fix: Make data preparation robust and efficient

### DIFF
--- a/backtester/feature_extraction/prepare_dataset.py
+++ b/backtester/feature_extraction/prepare_dataset.py
@@ -79,7 +79,7 @@ def _load_and_process_depth_in_batches(file_path: str, time_filter: list, batch_
         # Создаем фильтр, совместимый с pyarrow.dataset
         filter_expression = (ds.field('event_time') >= chunk_start) & (ds.field('event_time') < chunk_end)
 
-        dataset = ds.parquet_dataset(file_path, use_legacy_dataset=False)
+        dataset = ds.parquet_dataset(file_path)
 
         processed_batches = []
 
@@ -106,7 +106,11 @@ def _load_and_process_depth_in_batches(file_path: str, time_filter: list, batch_
 
     except Exception as e:
         print(f"ERROR: Ошибка при пакетной загрузке данных стакана: {e}")
-        return pd.DataFrame(columns=['bids', 'asks'])
+        # Возвращаем пустой DataFrame с правильной структурой, чтобы избежать MergeError
+        empty_df = pd.DataFrame({'bids': pd.Series(dtype='object'), 'asks': pd.Series(dtype='object')})
+        empty_df.index = pd.to_datetime([]).tz_localize('UTC')
+        empty_df.index.name = 'event_time'
+        return empty_df
 
 
 def set_memory_limit(gb_limit: int):


### PR DESCRIPTION
This commit resolves a series of errors in the `prepare_dataset.py` script, making the data processing pipeline both robust and memory-efficient.

The key changes are:

- refactor(loading): Re-implemented the depth data loading to use `pyarrow.dataset`. This enables predicate pushdown, filtering data at the source for significant performance and memory improvements.
- fix(filter): Corrected the column name in the liquidations filter from 'time' to 'event_time'.
- fix(compatibility): Removed the deprecated `use_legacy_dataset` argument from the `parquet_dataset` call to ensure compatibility with recent pyarrow versions.
- chore(robustness): Improved the error handling in the batch loading function to return a correctly indexed and typed empty DataFrame, preventing potential `MergeError` exceptions downstream.