### PR TITLE
fix: Stabilize data processing pipeline

### DIFF
--- a/backtester/feature_extraction/features.py
+++ b/backtester/feature_extraction/features.py
@@ -236,9 +236,9 @@ def calculate_orderbook_imbalance(df: pd.DataFrame, levels: int = 5) -> pd.Serie
         bids = row['bids']
         asks = row['asks']
 
-        # Проверяем, что данные не пустые. Прямая проверка `if not bids` может
-        # вызвать ValueError для сложных объектов. Явная проверка надежнее.
-        if bids is None or asks is None or len(bids) == 0 or len(asks) == 0:
+        # Добавляем "защитный" код: проверяем, что данные являются списками и они не пустые.
+        # Это предотвращает TypeError, если на вход попадает NaN или другой некорректный тип.
+        if not isinstance(bids, list) or not isinstance(asks, list) or not bids or not asks:
             return 0.0
 
         # Суммируем объемы на заданном количестве уровней


### PR DESCRIPTION
This commit resolves a series of errors in the data preparation scripts by prioritizing stability and robustness.

- revert: Reverted the depth data loading in `prepare_dataset.py` back to a stable implementation using `ParquetFile.iter_batches` with manual filtering. This avoids compatibility issues found with the `pyarrow.dataset` API in the target environment.

- fix(features): Added a defensive type check in the `calculate_orderbook_imbalance` function to prevent `TypeError` when processing malformed or missing order book data (e.g., NaN values).

- fix(filter): Corrected the column name in the liquidations filter from 'time' to 'event_time' to match the data schema.

- chore(robustness): Ensured the error handling in the data loading function returns a correctly indexed empty DataFrame to prevent downstream `MergeError` issues.